### PR TITLE
Cache CO2 scaling and sorted countries for performance

### DIFF
--- a/Clima/Managers & Helpers/CountryDataManager.swift
+++ b/Clima/Managers & Helpers/CountryDataManager.swift
@@ -9,35 +9,41 @@ import Foundation
 
 final class CountryDataManager: ObservableObject {
     @Published var countries: [Country] = []
-    
+
+    // Pre-computed once at load — data never changes after init
+    private(set) var logCO2Scale: (min: Double, range: Double) = (0, 1)
+    private(set) var countriesSortedByClimaJusticeScore: [Country] = []
+
     required init() {
         loadData()
     }
-    
+
     func loadData() {
         let decoder = JSONDecoder()
-        
+
         do {
             guard let countriesPath = Bundle.main.url(forResource: "clima_countries_data", withExtension: "json") else {
                 print("Error: Cannot find JSON files in bundle")
                 return
             }
             let countriesData = try Data(contentsOf: countriesPath)
-            
+
             self.countries = try decoder.decode([Country].self, from: countriesData)
+
+            logCO2Scale = self.countries.logCO2Scaling()
+            countriesSortedByClimaJusticeScore = self.countries.sorted {
+                $0.getClimaJusticeScore(minLog: logCO2Scale.min, rangeLog: logCO2Scale.range) >
+                $1.getClimaJusticeScore(minLog: logCO2Scale.min, rangeLog: logCO2Scale.range)
+            }
         } catch {
             print("Error decoding JSON data: \(error)")
         }
     }
-    
+
     func getCountryClimaJusticeScoreRank(for country: Country) -> Int {
-        let (minLog, rangeLog) = self.countries.logCO2Scaling()
-        let sortedCountries = countries.sorted(by: { $0.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) > $1.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) })
-        
-        guard let index = sortedCountries.firstIndex(of: country) else {
+        guard let index = countriesSortedByClimaJusticeScore.firstIndex(of: country) else {
             return 0
         }
-        
         return index + 1
     }
 }

--- a/Clima/Models & Data/Country.swift
+++ b/Clima/Models & Data/Country.swift
@@ -117,10 +117,10 @@ extension Array where Element == Country {
         case .nameZtoA:
             return filteredCountriesWithSearchText.sorted { $0.name > $1.name }
         case .climaJusticeScoreHighToLow:
-            let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+            let (minLog, rangeLog) = countryDataManager.logCO2Scale
             return filteredCountriesWithSearchText.sorted { $0.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) > $1.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) }
         case .climaJusticeScoreLowToHigh:
-            let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+            let (minLog, rangeLog) = countryDataManager.logCO2Scale
             return filteredCountriesWithSearchText.sorted { $0.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) < $1.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) }
         case .ndGainScoreHighToLow:
             return filteredCountriesWithSearchText.sorted { $0.NDGainScore > $1.NDGainScore }

--- a/Clima/Views/Screens/ChartsView.swift
+++ b/Clima/Views/Screens/ChartsView.swift
@@ -205,7 +205,7 @@ struct ChartsView: View {
                 .padding(.bottom)
             
             Chart {
-                let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+                let (minLog, rangeLog) = countryDataManager.logCO2Scale
                 
                 ForEach(countryDataManager.countries.sorted(by: { $0.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) > $1.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) }).prefix(10)) { country in
                     BarMark(
@@ -240,7 +240,7 @@ struct ChartsView: View {
                 .padding(.bottom)
             
             Chart {
-                let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+                let (minLog, rangeLog) = countryDataManager.logCO2Scale
                 
                 ForEach(countryDataManager.countries.sorted(by: { $0.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) < $1.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog) }).prefix(10)) { country in
                     BarMark(
@@ -333,7 +333,7 @@ struct ChartsView: View {
                 .padding(.bottom)
             
             Chart {
-                let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+                let (minLog, rangeLog) = countryDataManager.logCO2Scale
                 
                 ForEach(Region.allCases) { region in
                     let countries = countryDataManager.countries.filter { $0.getRegion() == region }
@@ -407,7 +407,7 @@ struct ChartsView: View {
                 .padding(.bottom)
             
             Chart {
-                let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+                let (minLog, rangeLog) = countryDataManager.logCO2Scale
                 
                 ForEach(countryDataManager.countries) { country in
                     PointMark(
@@ -452,7 +452,7 @@ struct ChartsView: View {
                 .padding(.bottom)
             
             Chart {
-                let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+                let (minLog, rangeLog) = countryDataManager.logCO2Scale
                 
                 ForEach(countryDataManager.countries) { country in
                     PointMark(

--- a/Clima/Views/Screens/CompareView.swift
+++ b/Clima/Views/Screens/CompareView.swift
@@ -260,7 +260,7 @@ struct CompareView: View {
     }
     
     private func comparisonView(leftCountry: Country, rightCountry: Country) -> some View {
-        let (minLog, rangeLog) = countryDataManager.countries.logCO2Scaling()
+        let (minLog, rangeLog) = countryDataManager.logCO2Scale
         let leftClimaJusticeScore = leftCountry.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog)
         let rightClimaJusticeScore = rightCountry.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog)
         

--- a/Clima/Views/Screens/MapView.swift
+++ b/Clima/Views/Screens/MapView.swift
@@ -50,7 +50,7 @@ struct MapView: View {
             ZStack(alignment: .trailing) {
                 Map(position: $mapCameraPosition) {
                     ForEach(self.displayedCountriesOnMap) { country in
-                        let (minLog, rangeLog) = self.countryDataManager.countries.logCO2Scaling()
+                        let (minLog, rangeLog) = self.countryDataManager.logCO2Scale
                         let climaJusticeScore = country.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog)
                         
                         MapCircle(center: country.getCoordinate(), radius: 500000 * country.getScaleFactor(for: climaJusticeScore))
@@ -162,9 +162,9 @@ struct MapView: View {
     @ViewBuilder
     private func countryDetailViewContent(country: Country) -> some View {
         ScrollView {
-            let (minLog, rangeLog) = self.countryDataManager.countries.logCO2Scaling()
+            let (minLog, rangeLog) = self.countryDataManager.logCO2Scale
             let climaJusticeScore = country.getClimaJusticeScore(minLog: minLog, rangeLog: rangeLog)
-            
+
             VStack(spacing: 15) {
                 Spacer().frame(height: 10)
                 


### PR DESCRIPTION
## Summary
This PR optimizes performance by pre-computing and caching the CO2 logarithmic scaling values and the countries sorted by Clima Justice Score at initialization time, rather than recalculating them repeatedly throughout the app.

## Key Changes
- **CountryDataManager**: Added two new cached properties computed once during `loadData()`:
  - `logCO2Scale`: Pre-computed min and range values for CO2 logarithmic scaling
  - `countriesSortedByClimaJusticeScore`: Countries pre-sorted by Clima Justice Score in descending order
  
- **Updated all references** across the codebase to use the cached values instead of recalculating:
  - `ChartsView.swift`: 5 chart sections now use `countryDataManager.logCO2Scale`
  - `MapView.swift`: Map rendering and country detail view use cached scaling
  - `Country.swift`: Sorting extension uses cached scaling values
  - `CompareView.swift`: Comparison view uses cached scaling

- **Simplified ranking logic**: `getCountryClimaJusticeScoreRank()` now uses the pre-sorted array instead of sorting on each call

## Implementation Details
- The cached properties are marked as `private(set)` to maintain encapsulation while allowing read access
- Computation happens once during initialization when `loadData()` is called
- This eliminates redundant sorting and scaling calculations that were happening on every view render
- The change is backward compatible and doesn't affect the public API

https://claude.ai/code/session_01S75fbLjhVytmBgXjgo6z84